### PR TITLE
Issue #90: plugin does not handle default connection types

### DIFF
--- a/src/it/metricshub-connectors/verify.groovy
+++ b/src/it/metricshub-connectors/verify.groovy
@@ -199,8 +199,8 @@ assert htmlText.indexOf("This connector is not available for remote hosts") > - 
 // lmsensors
 htmlText = new File(basedir, "target/site/connectors/lmsensors.html").text
 assert htmlText =~ /metricshub.*-t linux.*--ssh.*--sudo-command-list/ : "lmsensors: CLI must specify linux and ssh and use --sudo-command-list"
-assert htmlText.indexOf("This connector is not available for the local host") > -1 : "MySQL: Page must indicate 'This connector is not available for the local host' message"
-assert htmlText.indexOf("This connector is not available for remote hosts") > - 1 : "MySQL: Page must indicate 'This connector is not available for remote hosts' message"
+assert htmlText.indexOf("This connector is not available for the local host") > -1 : "lmsensors: Page must indicate 'This connector is not available for the local host' message"
+assert htmlText.indexOf("This connector is not available for remote hosts") > - 1 : "lmsensors: Page must indicate 'This connector is not available for remote hosts' message"
 
 // MIB2
 htmlText = new File(basedir, "target/site/connectors/mib2.html").text


### PR DESCRIPTION
This pull request includes a minor change to the `src/it/metricshub-connectors/verify.groovy` file. The change corrects the error messages associated with the `lmsensors` connector to ensure they accurately reflect the connector being tested.

* [`src/it/metricshub-connectors/verify.groovy`](diffhunk://#diff-e747fa09044d8b4b5b7484e47f80c29de3fcd8416680691b23e556f472e56e4eL202-R203): Updated error messages to correctly indicate the `lmsensors` connector instead of `MySQL`.